### PR TITLE
Renamed HTML files in basics folder to PHP and update links

### DIFF
--- a/basics/01_introduction.php
+++ b/basics/01_introduction.php
@@ -325,7 +325,7 @@
             <button onclick="window.location.href='index.html'">Back to Course Home</button>
         </div>
         <div>
-            <button onclick="window.location.href='02_document_structure.html'">Next Lesson: HTML Document Structure</button>
+            <button onclick="window.location.href='02_document_structure.php'">Next Lesson: HTML Document Structure</button>
         </div>
     </div>
 </body>

--- a/basics/02_document_structure.php
+++ b/basics/02_document_structure.php
@@ -413,10 +413,10 @@
     
     <div class="navigation">
         <div>
-            <button onclick="window.location.href='01_introduction.html'">Previous Lesson: Introduction to HTML</button>
+            <button onclick="window.location.href='01_introduction.php'">Previous Lesson: Introduction to HTML</button>
         </div>
         <div>
-            <button onclick="window.location.href='03_text_elements.html'">Next Lesson: Text Elements and Typography</button>
+            <button onclick="window.location.href='03_text_elements.php'">Next Lesson: Text Elements and Typography</button>
         </div>
     </div>
 </body>

--- a/basics/03_text_elements.php
+++ b/basics/03_text_elements.php
@@ -508,10 +508,10 @@ Let stand for 2 minutes, then remove to cool on wire racks.</textarea>
     
     <div class="navigation">
         <div>
-            <button onclick="window.location.href='02_document_structure.html'">Previous Lesson: HTML Document Structure</button>
+            <button onclick="window.location.href='02_document_structure.php'">Previous Lesson: HTML Document Structure</button>
         </div>
         <div>
-            <button onclick="window.location.href='04_links.html'">Next Lesson: Links and Navigation</button>
+            <button onclick="window.location.href='04_links.php'">Next Lesson: Links and Navigation</button>
         </div>
     </div>
 </body>

--- a/basics/04_links.php
+++ b/basics/04_links.php
@@ -661,10 +661,10 @@
     
     <div class="navigation">
         <div>
-            <button onclick="window.location.href='03_text_elements.html'">Previous Lesson: Text Elements and Typography</button>
+            <button onclick="window.location.href='03_text_elements.php'">Previous Lesson: Text Elements and Typography</button>
         </div>
         <div>
-            <button onclick="window.location.href='05_images.html'">Next Lesson: Images and Multimedia</button>
+            <button onclick="window.location.href='05_images.php'">Next Lesson: Images and Multimedia</button>
         </div>
     </div>
 </body>

--- a/basics/05_images.php
+++ b/basics/05_images.php
@@ -705,10 +705,10 @@
     
     <div class="navigation">
         <div>
-            <button onclick="window.location.href='04_links.html'">Previous Lesson: Links and Navigation</button>
+            <button onclick="window.location.href='04_links.php'">Previous Lesson: Links and Navigation</button>
         </div>
         <div>
-            <button onclick="window.location.href='06_lists.html'">Next Lesson: Lists</button>
+            <button onclick="window.location.href='06_lists.php'">Next Lesson: Lists</button>
         </div>
     </div>
 </body>

--- a/basics/06_lists.php
+++ b/basics/06_lists.php
@@ -807,10 +807,10 @@
     
     <div class="navigation">
         <div>
-            <button onclick="window.location.href='05_images.html'">Previous Lesson: Images and Multimedia</button>
+            <button onclick="window.location.href='05_images.php'">Previous Lesson: Images and Multimedia</button>
         </div>
         <div>
-            <button onclick="window.location.href='07_tables.html'">Next Lesson: Tables</button>
+            <button onclick="window.location.href='07_tables.php'">Next Lesson: Tables</button>
         </div>
     </div>
 </body>

--- a/basics/07_tables.php
+++ b/basics/07_tables.php
@@ -978,10 +978,10 @@
     
     <div class="navigation">
         <div>
-            <button onclick="window.location.href='06_lists.html'">Previous Lesson: Lists</button>
+            <button onclick="window.location.href='06_lists.php'">Previous Lesson: Lists</button>
         </div>
         <div>
-            <button onclick="window.location.href='08_forms.html'">Next Lesson: Forms and Input Elements</button>
+            <button onclick="window.location.href='08_forms.php'">Next Lesson: Forms and Input Elements</button>
         </div>
     </div>
 </body>

--- a/basics/08_forms.php
+++ b/basics/08_forms.php
@@ -1323,7 +1323,7 @@
     
     <div class="navigation">
         <div>
-            <button onclick="window.location.href='07_tables.html'">Previous Lesson: Tables</button>
+            <button onclick="window.location.href='07_tables.php'">Previous Lesson: Tables</button>
         </div>
         <div>
             <button onclick="window.location.href='../index.html'">Back to Course Home</button>


### PR DESCRIPTION
I renamed all .html files within the /basics directory to .php extensions. I also updated all internal navigation links (next/previous lesson) within these files to reflect the new .php extensions.

The "Back to Course Home" links (e.g., href='../index.html') were intentionally left unchanged as they point outside the /basics directory.