### PR TITLE
Refactor: Convert decrease_gasergy.php to PDO and add logging

### DIFF
--- a/ai_chat/index.html
+++ b/ai_chat/index.html
@@ -914,7 +914,7 @@ i18n: {
             };
             
             // Start the process after a short initial delay to allow chat JS to potentially load
-            setTimeout(findAndObserve, 700);
+            setTimeout(findAndObserve, 700); 
         };
 
         // Call the observer initialization function.

--- a/gasergy/decrease_gasergy.php
+++ b/gasergy/decrease_gasergy.php
@@ -3,62 +3,87 @@ session_start();
 
 header('Content-Type: application/json');
 
+// --- Debug Logging Setup ---
+$log_file = __DIR__ . '/../../gasergy_debug.log'; // Log file in project root
+$log_prefix = '[' . date('Y-m-d H:i:s') . ' decrease_gasergy] ';
+
+function write_log($message) {
+    global $log_file, $log_prefix;
+    $formatted_message = is_string($message) ? $message : print_r($message, true);
+    file_put_contents($log_file, $log_prefix . $formatted_message . "\n", FILE_APPEND);
+}
+
+write_log('--- Script Start ---');
+write_log('POST data: ' . print_r($_POST, true));
+write_log('SESSION data: ' . print_r($_SESSION, true));
+
+// --- User Authentication Check ---
 if (!isset($_SESSION['user_id'])) {
+    write_log('Error: User not logged in.');
     echo json_encode(["success" => false, "message" => "User not logged in"]);
     exit;
 }
-
-require_once '../auth-system/config/db.php'; // Corrected path based on ls output
-
-$amount = isset($_POST['amount']) ? (int)$_POST['amount'] : 30;
 $user_id = $_SESSION['user_id'];
+write_log('User ID: ' . $user_id);
 
-$conn = getDBConnection(); // Assumes db.php provides this function or $conn variable
+// --- Database Connection and Operations ---
+try {
+    write_log('Requiring db.php...');
+    require_once '../auth-system/config/db.php'; // This should make $pdo available
+    write_log('db.php included.');
 
-if (!$conn) {
-    echo json_encode(["success" => false, "message" => "Database connection failed"]);
-    exit;
-}
-
-// Decrease gasergy_balance
-$sql_update = "UPDATE users SET gasergy_balance = gasergy_balance - ? WHERE id = ?";
-$stmt_update = $conn->prepare($sql_update);
-
-if (!$stmt_update) {
-    echo json_encode(["success" => false, "message" => "Failed to prepare update statement: " . $conn->error]);
-    $conn->close();
-    exit;
-}
-
-$stmt_update->bind_param("ii", $amount, $user_id);
-
-if ($stmt_update->execute()) {
-    // Fetch the new balance
-    $sql_select = "SELECT gasergy_balance FROM users WHERE id = ?";
-    $stmt_select = $conn->prepare($sql_select);
-
-    if (!$stmt_select) {
-        echo json_encode(["success" => false, "message" => "Failed to prepare select statement: " . $conn->error]);
-        $stmt_update->close();
-        $conn->close();
+    if (!isset($pdo) || !$pdo instanceof PDO) {
+        write_log('Error: $pdo object is not available or not a PDO instance after including db.php.');
+        echo json_encode(["success" => false, "message" => "Database connection configuration error."]);
         exit;
     }
+    write_log('$pdo object is available.');
 
-    $stmt_select->bind_param("i", $user_id);
-    $stmt_select->execute();
-    $result = $stmt_select->get_result();
-    
-    if ($row = $result->fetch_assoc()) {
-        echo json_encode(["success" => true, "new_balance" => $row['gasergy_balance']]);
+    $amount = isset($_POST['amount']) ? (int)$_POST['amount'] : 30;
+    write_log('Amount to decrease: ' . $amount);
+
+    // Decrease gasergy_balance
+    $sql_update = "UPDATE users SET gasergy_balance = gasergy_balance - :amount WHERE id = :user_id";
+    write_log('Preparing update SQL: ' . $sql_update);
+    $stmt_update = $pdo->prepare($sql_update);
+
+    write_log('Executing update statement with amount=' . $amount . ', user_id=' . $user_id);
+    $update_success = $stmt_update->execute([':amount' => $amount, ':user_id' => $user_id]);
+
+    if ($update_success) {
+        write_log('Update statement executed successfully. Rows affected: ' . $stmt_update->rowCount());
+
+        // Fetch the new balance
+        $sql_select = "SELECT gasergy_balance FROM users WHERE id = :user_id";
+        write_log('Preparing select SQL: ' . $sql_select);
+        $stmt_select = $pdo->prepare($sql_select);
+
+        write_log('Executing select statement with user_id=' . $user_id);
+        $stmt_select->execute([':user_id' => $user_id]);
+        $row = $stmt_select->fetch(PDO::FETCH_ASSOC);
+
+        if ($row) {
+            write_log('New balance fetched: ' . $row['gasergy_balance']);
+            echo json_encode(["success" => true, "new_balance" => $row['gasergy_balance']]);
+        } else {
+            write_log('Error: Failed to fetch new balance for user_id=' . $user_id . ' after update.');
+            echo json_encode(["success" => false, "message" => "Failed to fetch new balance"]);
+        }
+        $stmt_select->closeCursor(); // Good practice for PDO select
     } else {
-        // This case should ideally not happen if the user exists and update was successful
-        echo json_encode(["success" => false, "message" => "Failed to fetch new balance"]);
+        $errorInfo = $stmt_update->errorInfo();
+        write_log('Error: Failed to execute update statement. Error: ' . print_r($errorInfo, true));
+        echo json_encode(["success" => false, "message" => "Failed to update balance: " . (isset($errorInfo[2]) ? $errorInfo[2] : 'Unknown database error')]);
     }
-    $stmt_select->close();
-} else {
-    echo json_encode(["success" => false, "message" => "Failed to update balance: " . $stmt_update->error]);
+    // $stmt_update->closeCursor(); // Not strictly necessary for update, but doesn't hurt
+
+} catch (PDOException $e) {
+    write_log('PDOException caught: ' . $e->getMessage() . ' (Code: ' . $e->getCode() . ')');
+    echo json_encode(["success" => false, "message" => "Database error: " . $e->getMessage()]);
+} catch (Exception $e) {
+    write_log('General Exception caught: ' . $e->getMessage() . ' (Code: ' . $e->getCode() . ')');
+    echo json_encode(["success" => false, "message" => "An unexpected error occurred: " . $e->getMessage()]);
 }
 
-$stmt_update->close();
-$conn->close();
+write_log('--- Script End ---');
 ?>

--- a/index.php
+++ b/index.php
@@ -1276,7 +1276,7 @@ if (isset($_SESSION['user_id'])) {
 
     // Start the polling process for the gasergy display element.
     // Subsequent polling for other elements is chained within the success callbacks.
-    findGasergyDisplay();
+    findGasergyDisplay(); 
   };
 
   // Call the observer initialization function.


### PR DESCRIPTION
This commit refactors `gasergy/decrease_gasergy.php` to use PDO for all database operations, ensuring consistency with the database connection provided by `auth-system/config/db.php`.

Changes include:
- Replaced mysqli_* functions with their PDO equivalents.
- Ensured the script uses the existing `$pdo` object from `db.php`.
- Added comprehensive debug logging to `gasergy_debug.log` (located in the project root) to trace script execution, received data (POST, SESSION), database interactions, and potential errors.
- Implemented try-catch blocks for PDOExceptions to handle database errors gracefully and provide informative JSON responses.

This change is made to address a server-side 500 error that was occurring due to the previous mysqli/PDO object mismatch. I will confirm the resolution of this error next.