### PR TITLE
Fix duplicate session handling in get.php

### DIFF
--- a/gasergy/get.php
+++ b/gasergy/get.php
@@ -4,14 +4,6 @@ file_put_contents(__DIR__ . '/get_debug.log', date('c') . " get.php\n", FILE_APP
 
 if (!isset($_SESSION['user_id'])) {
     file_put_contents(__DIR__ . '/get_debug.log', "Not logged in\n", FILE_APPEND);
-    header('Location: /auth-system/login.html');
-    exit;
-}
-?>
-
-<?php
-session_start();
-if (!isset($_SESSION['user_id'])) {
     header('Location: /auth-system/frt_login.php');
     exit;
 }


### PR DESCRIPTION
## Summary
- clean up duplicated PHP blocks in `gasergy/get.php`
- use a single session and redirect to `frt_login.php`

## Testing
- `php -l gasergy/get.php`

------
https://chatgpt.com/codex/tasks/task_e_684b3d9af79c8321b9d6615366fd5598