### PR TITLE
Fix out-of-gasergy display

### DIFF
--- a/assets/js/chat-logic.js
+++ b/assets/js/chat-logic.js
@@ -156,12 +156,15 @@ function initGasergyObserver(gasergyConfig, chatTargetSelector) {
                 const chatTargetElement = document.querySelector(chatTargetSelector);
                 if (chatTargetElement) {
                   const messagesContainer = chatTargetElement.querySelector('.chat-messages-list');
-                  if (messagesContainer) {
-                    displayOutOfGasergyMessage(
-                      gasergyConfig.refillPath,
-                      messagesContainer,
-                      chatTargetSelector 
-                    );
+                    if (messagesContainer) {
+                      if (newestMessage && newestMessage.parentNode) {
+                        newestMessage.remove();
+                      }
+                      displayOutOfGasergyMessage(
+                        gasergyConfig.refillPath,
+                        messagesContainer,
+                        chatTargetSelector
+                      );
                   } else {
                     console.error('Gasergy Observer: Could not find .chat-messages-list within', chatTargetSelector);
                   }


### PR DESCRIPTION
## Summary
- remove the newest bot message if the user's gasergy is depleted

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b3d984718832180d1b38aa5d045dc