### PR TITLE
Fix: Ensure 'Out of Gasergy' state is immediate on load

### DIFF
--- a/assets/js/chat-logic.js
+++ b/assets/js/chat-logic.js
@@ -1,3 +1,5 @@
+// File: assets/js/chat-logic.js
+
 import { createChat } from 'https://cdn.jsdelivr.net/npm/@n8n/chat/dist/chat.bundle.es.js';
 
 export function initializeN8NChat(config) {
@@ -25,65 +27,96 @@ export function initializeN8NChat(config) {
 function disableChatInput(chatTargetSelectorForInput) {
   const chatRootElement = document.querySelector(chatTargetSelectorForInput);
   if (!chatRootElement) {
-    console.error('Gasergy Observer: Could not find chat root element for input disabling:', chatTargetSelectorForInput);
+    // console.error('Gasergy Observer: Could not find chat root element for input disabling:', chatTargetSelectorForInput);
     return false;
   }
 
   const inputElement = chatRootElement.querySelector('.chat-input .chat-inputs textarea');
   if (inputElement) {
-    inputElement.disabled = true;
-    inputElement.placeholder = 'Gasergy depleted. Please recharge.';
-    console.log('Gasergy Observer: Chat input disabled using selector:', chatTargetSelectorForInput + ' .chat-input .chat-inputs textarea');
+    if (!inputElement.disabled) {
+      inputElement.disabled = true;
+      inputElement.placeholder = 'Gasergy depleted. Please recharge.';
+      console.log('Gasergy Observer: Chat input disabled using selector:', chatTargetSelectorForInput + ' .chat-input .chat-inputs textarea');
+    } else {
+      // console.log('Gasergy Observer: Chat input already disabled (main selector).');
+    }
     return true;
   }
 
   const fallbackInputElement = chatRootElement.querySelector('textarea');
   if (fallbackInputElement) {
-    fallbackInputElement.disabled = true;
-    fallbackInputElement.placeholder = 'Gasergy depleted. Please recharge.';
-    console.warn('Gasergy Observer: Used fallback selector to disable textarea:', chatTargetSelectorForInput + ' textarea');
+    if (!fallbackInputElement.disabled) {
+      fallbackInputElement.disabled = true;
+      fallbackInputElement.placeholder = 'Gasergy depleted. Please recharge.';
+      console.warn('Gasergy Observer: Used fallback selector to disable textarea:', chatTargetSelectorForInput + ' textarea');
+    } else {
+      // console.log('Gasergy Observer: Chat input already disabled (fallback selector).');
+    }
     return true;
   }
 
-  console.error('Gasergy Observer: Could not find chat input textarea using specific or fallback selectors within:', chatTargetSelectorForInput);
+  // console.error('Gasergy Observer: Could not find chat input textarea using specific or fallback selectors for disabling within:', chatTargetSelectorForInput);
   return false;
 }
 
 function displayOutOfGasergyMessage(refillPath, messagesContainerElement, chatTargetSelectorForInput) {
-  const messageDiv = document.createElement('div');
-  messageDiv.className = 'chat-message chat-message-from-bot'; 
-
-  const markdownDiv = document.createElement('div');
-  markdownDiv.className = 'chat-message-markdown';
-
-  const p = document.createElement('p');
-  const actualRefillPath = refillPath || '#'; 
-  if (!refillPath) {
-      console.warn('Gasergy Observer: refillPath not provided for OutOfGasergyMessage. Using "#" as fallback.');
+  if (!messagesContainerElement) {
+    console.error('Gasergy Observer: messagesContainerElement is null in displayOutOfGasergyMessage. Cannot display message or disable input.');
+    return;
   }
-  p.innerHTML = `I am out of Gasergy. As an SRN Master HTML AI assistant, I need Gasergy to continue functioning. Please re-charge my tank: <a href='${actualRefillPath}' target='_blank'>Get Gasergy</a>`;
-  
-  markdownDiv.appendChild(p);
-  messageDiv.appendChild(markdownDiv);
-  messagesContainerElement.appendChild(messageDiv);
 
-  // Ensure Scroll-to-Bottom
-  messagesContainerElement.scrollTop = messagesContainerElement.scrollHeight;
-  console.log('Gasergy Observer: "Out of Gasergy" message displayed.');
+  const existingMessages = messagesContainerElement.querySelectorAll('.chat-message-markdown p');
+  let messageExists = false;
+  existingMessages.forEach(existingP => {
+    if (existingP.textContent.includes("I am out of Gasergy.")) {
+      messageExists = true;
+    }
+  });
 
+  if (!messageExists) {
+    const messageDiv = document.createElement('div');
+    messageDiv.className = 'chat-message chat-message-from-bot';
+
+    const markdownDiv = document.createElement('div');
+    markdownDiv.className = 'chat-message-markdown';
+
+    const p = document.createElement('p');
+    const actualRefillPath = refillPath || '#';
+    if (!refillPath) {
+        console.warn('Gasergy Observer: refillPath not provided for OutOfGasergyMessage. Using "#" as fallback.');
+    }
+    p.innerHTML = `I am out of Gasergy. As an SRN Master HTML AI assistant, I need Gasergy to continue functioning. Please re-charge my tank: <a href='${actualRefillPath}' target='_blank'>Get Gasergy</a>`;
+
+    markdownDiv.appendChild(p);
+    messageDiv.appendChild(markdownDiv);
+    messagesContainerElement.appendChild(messageDiv);
+    messagesContainerElement.scrollTop = messagesContainerElement.scrollHeight;
+    console.log('Gasergy Observer: "Out of Gasergy" message displayed.');
+  } else {
+    // console.log('Gasergy Observer: "Out of Gasergy" message already exists. Not adding duplicate.');
+  }
+
+  // Attempt to disable input, retry if necessary
   if (!disableChatInput(chatTargetSelectorForInput)) {
+    let attempts = 0;
+    const maxAttempts = 50; // Max attempts (e.g., 50 * 100ms = 5 seconds)
     const intervalId = setInterval(() => {
+      attempts++;
       if (disableChatInput(chatTargetSelectorForInput)) {
         clearInterval(intervalId);
+        // console.log('Gasergy Observer: Chat input disabled after attempts in displayOutOfGasergyMessage.');
+      } else if (attempts >= maxAttempts) {
+        clearInterval(intervalId);
+        console.error('Gasergy Observer: Failed to disable chat input after multiple attempts in displayOutOfGasergyMessage.');
       }
-    }, 500);
+    }, 100); // Retry interval (e.g., every 100ms)
   }
 }
 
 function initGasergyObserver(gasergyConfig, chatTargetSelector) {
   console.log("Initializing Gasergy observer with config:", gasergyConfig, "and chat target selector:", chatTargetSelector);
 
-  let gasergyDepletedMessageShown = false; // Flag to ensure message is shown only once
+  let gasergyDepletedMessageShown = false;
 
   const chatContainer = document.querySelector(chatTargetSelector);
   if (!chatContainer) {
@@ -91,142 +124,149 @@ function initGasergyObserver(gasergyConfig, chatTargetSelector) {
     return;
   }
 
-  const messagesList = chatContainer.querySelector('.chat-messages-list');
-  if (!messagesList) {
-    console.error("Gasergy Observer: Chat messages list not found within chat container using selector .chat-messages-list on element:", chatContainer);
-    return;
-  }
-
-  let balanceDisplayElement = null;
-  if (gasergyConfig.balanceDisplaySelector) {
-    balanceDisplayElement = document.querySelector(gasergyConfig.balanceDisplaySelector);
-    if (!balanceDisplayElement) {
-      console.warn("Gasergy Observer: Balance display element not found with selector:", gasergyConfig.balanceDisplaySelector);
-    } else {
-      console.log("Gasergy Observer: Found balance display element:", balanceDisplayElement);
+  const setupObserverAndBalance = (currentMessagesList) => {
+    if (!currentMessagesList) {
+        console.error("Gasergy Observer: currentMessagesList is null in setupObserverAndBalance. Cannot proceed.");
+        return;
     }
-  } else {
-    console.log("Gasergy Observer: No balanceDisplaySelector provided in config.");
-  }
-
-  if (gasergyConfig.balancePath) {
-    fetch(gasergyConfig.balancePath)
-      .then((response) => {
-        if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-        return response.json();
-      })
-      .then((data) => {
-        if (typeof data.balance !== 'undefined') {
-          if (balanceDisplayElement) {
-            balanceDisplayElement.textContent = 'Gasergy balance: ⚡ ' + data.balance;
-          }
-          if (data.balance <= 0) {
-            gasergyDepletedMessageShown = true;
-            displayOutOfGasergyMessage(
-              gasergyConfig.refillPath,
-              messagesList,
-              chatTargetSelector
-            );
-          }
-        }
-      })
-      .catch((err) => console.error('Gasergy Observer: Error fetching balance:', err));
-  } else {
-    console.warn('Gasergy Observer: balancePath not provided in config.');
-  }
-
-  const observer = new MutationObserver((mutationsList, observer) => {
-    if (gasergyDepletedMessageShown) {
-      // console.log('Gasergy Observer: Depleted message already shown, skipping further processing.'); // Optional for debugging
-      return;
+    let balanceDisplayElement = null;
+    if (gasergyConfig.balanceDisplaySelector) {
+      balanceDisplayElement = document.querySelector(gasergyConfig.balanceDisplaySelector);
+      if (!balanceDisplayElement) {
+        console.warn("Gasergy Observer: Balance display element not found with selector:", gasergyConfig.balanceDisplaySelector);
+      }
     }
 
-    for (const mutation of mutationsList) {
-      console.log('Gasergy Observer: Mutation detected:', mutation); 
-
-      if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
-        mutation.addedNodes.forEach(node => { 
-          console.log('Gasergy Observer: Checking added node:', node);
-          if (node.nodeType === Node.ELEMENT_NODE) {
-            console.log('Gasergy Observer: Node classes:', node.classList);
-            console.log('Gasergy Observer: Node dataset.gasergyProcessed:', node.dataset.gasergyProcessed);
-            const markdownContent = node.querySelector('.chat-message-markdown p');
-            console.log('Gasergy Observer: Node querySelector .chat-message-markdown p:', markdownContent ? markdownContent.textContent : null);
-          }
-        });
-
-        const newBotMessages = Array.from(mutation.addedNodes).filter(node =>
-          node.nodeType === Node.ELEMENT_NODE &&
-          node.classList.contains('chat-message') &&
-          node.classList.contains('chat-message-from-bot') &&
-          !node.dataset.gasergyProcessed && 
-          node.querySelector('.chat-message-markdown p') 
-        );
-
-        if (newBotMessages.length > 0) {
-          const newestMessage = newBotMessages[newBotMessages.length - 1];
-          newestMessage.dataset.gasergyProcessed = 'true'; 
-          console.log('Gasergy Observer: New bot message detected. Contents:', newestMessage.textContent);
-
-          const formData = new URLSearchParams();
-          formData.append('amount', '30'); 
-
-          fetch(gasergyConfig.fetchPath, { 
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/x-www-form-urlencoded', 
-            },
-            body: formData
-          })
-          .then(response => {
-            if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-            return response.json();
-          })
-          .then(data => {
-            console.log('Gasergy Observer: API response data:', data); 
-            if (data.success && typeof data.balance !== 'undefined') {
-              if (balanceDisplayElement) { 
-                balanceDisplayElement.textContent = 'Gasergy balance: ⚡ ' + data.balance;
-                console.log('Gasergy Observer: Balance updated to:', data.balance);
-              } else {
-                console.log('Gasergy Observer: Balance updated (no display element):', data.balance);
+    // Initial balance check
+    if (gasergyConfig.balancePath) {
+      fetch(gasergyConfig.balancePath)
+        .then((response) => {
+          if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+          return response.json();
+        })
+        .then((data) => {
+          if (typeof data.balance !== 'undefined') {
+            if (balanceDisplayElement) {
+              balanceDisplayElement.textContent = 'Gasergy balance: ⚡ ' + data.balance;
+            }
+            if (data.balance <= 0) {
+              if (!gasergyDepletedMessageShown) { // Check flag before showing message
+                console.log('Gasergy Observer: Initial balance is zero or less. Displaying out of gasergy message and disabling input.');
+                gasergyDepletedMessageShown = true; // Set flag
+                displayOutOfGasergyMessage(
+                  gasergyConfig.refillPath,
+                  currentMessagesList,
+                  chatTargetSelector
+                );
               }
+            }
+          }
+        })
+        .catch((err) => console.error('Gasergy Observer: Error fetching initial balance:', err));
+    } else {
+      console.warn('Gasergy Observer: balancePath not provided in config for initial check.');
+    }
 
-              if (data.balance <= 0) {
-                console.log('Gasergy Observer: Gasergy is zero or less. Current balance:', data.balance);
-                gasergyDepletedMessageShown = true; // Set the flag immediately
-                
-                const chatTargetElement = document.querySelector(chatTargetSelector);
-                if (chatTargetElement) {
-                  const messagesContainer = chatTargetElement.querySelector('.chat-messages-list');
-                    if (messagesContainer) {
+    const observer = new MutationObserver((mutationsList, obs) => {
+      // If Gasergy is already depleted, ensure input remains disabled and do not process new messages for Gasergy.
+      if (gasergyDepletedMessageShown) {
+        disableChatInput(chatTargetSelector);
+        return;
+      }
+
+      for (const mutation of mutationsList) {
+        if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+          const newBotMessages = Array.from(mutation.addedNodes).filter(node =>
+            node.nodeType === Node.ELEMENT_NODE &&
+            node.classList.contains('chat-message') &&
+            node.classList.contains('chat-message-from-bot') &&
+            !node.dataset.gasergyProcessed &&
+            node.querySelector('.chat-message-markdown p')
+          );
+
+          if (newBotMessages.length > 0) {
+            // If gasergyDepletedMessageShown became true due to another async operation
+            // before this message processing, just disable input and exit.
+            if (gasergyDepletedMessageShown) {
+                disableChatInput(chatTargetSelector);
+                return;
+            }
+
+            const newestMessage = newBotMessages[newBotMessages.length - 1];
+            newestMessage.dataset.gasergyProcessed = 'true';
+
+            const formData = new URLSearchParams();
+            formData.append('amount', '30');
+
+            fetch(gasergyConfig.fetchPath, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+              body: formData
+            })
+            .then(response => {
+              if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+              return response.json();
+            })
+            .then(data => {
+              if (data.success && typeof data.balance !== 'undefined') {
+                if (balanceDisplayElement) {
+                  balanceDisplayElement.textContent = 'Gasergy balance: ⚡ ' + data.balance;
+                }
+                if (data.balance <= 0) {
+                  if (!gasergyDepletedMessageShown) { // Check flag again before showing message
+                    console.log('Gasergy Observer: Gasergy is zero or less after deduction. Balance:', data.balance);
+                    gasergyDepletedMessageShown = true; // Set flag
+
+                    // Use currentMessagesList directly as it's already available in this scope
+                    if (currentMessagesList) {
                       if (newestMessage && newestMessage.parentNode) {
-                        newestMessage.remove();
+                        // It might be better to not remove the bot's last message that triggered
+                        // the Gasergy depletion, as it could be confusing for the user.
+                        // Instead, just display the "out of Gasergy" message.
+                        // newestMessage.remove();
                       }
                       displayOutOfGasergyMessage(
                         gasergyConfig.refillPath,
-                        messagesContainer,
+                        currentMessagesList, // Use the messages list from setupObserverAndBalance
                         chatTargetSelector
                       );
-                  } else {
-                    console.error('Gasergy Observer: Could not find .chat-messages-list within', chatTargetSelector);
+                    } else {
+                      // This case should ideally not be reached if setupObserverAndBalance was called with a valid currentMessagesList
+                      console.error('Gasergy Observer: currentMessagesList is unexpectedly null during deduction message display.');
+                    }
                   }
-                } else {
-                  console.error('Gasergy Observer: Could not find chat target element:', chatTargetSelector);
                 }
+              } else {
+                console.error('Gasergy Observer: Failed to update balance after deduction, API data:', data);
               }
-            } else {
-              console.error('Gasergy Observer: Failed to update balance, API data:', data);
-            }
-          })
-          .catch(error => {
-            console.error('Gasergy Observer: Error decreasing Gasergy:', error);
-          });
+            })
+            .catch(error => {
+              console.error('Gasergy Observer: Error decreasing Gasergy:', error);
+            });
+          }
         }
       }
-    }
-  });
+    });
 
-  observer.observe(messagesList, { childList: true, subtree: true }); 
-  console.log("Gasergy Observer: MutationObserver attached to messages list:", messagesList);
+    observer.observe(currentMessagesList, { childList: true, subtree: true });
+    // console.log("Gasergy Observer: MutationObserver attached to messages list:", currentMessagesList);
+  };
+
+  // Attempt to find .chat-messages-list, retry after a delay if not immediately available
+  let messagesList = chatContainer.querySelector('.chat-messages-list');
+  if (!messagesList) {
+    // console.log("Gasergy Observer: .chat-messages-list not found initially, will retry after a delay.");
+    setTimeout(() => {
+      const delayedMessagesList = chatContainer.querySelector('.chat-messages-list');
+      if (delayedMessagesList) {
+        // console.log("Gasergy Observer: Found .chat-messages-list after delay.");
+        setupObserverAndBalance(delayedMessagesList);
+      } else {
+        console.error("Gasergy Observer: Chat messages list (.chat-messages-list) not found even after delay. Gasergy logic might not work correctly.");
+      }
+    }, 750); // Delay for DOM rendering
+  } else {
+    // console.log("Gasergy Observer: Found .chat-messages-list immediately.");
+    setupObserverAndBalance(messagesList);
+  }
 }


### PR DESCRIPTION
Previously, users with zero or negative gasergy could send one message before the 'Out of Gasergy' UI state (disabled input, warning message) was triggered.

This commit refines `assets/js/chat-logic.js` to address this:

1.  The `displayOutOfGasergyMessage` function now employs a more aggressive retry mechanism (checking every 100ms for up to 5 seconds) to disable the chat input. This handles cases where the chat UI elements might not be immediately available when the initial gasergy balance check completes.
2.  The `initGasergyObserver` function was updated to better manage the `gasergyDepletedMessageShown` flag, ensuring that if gasergy is zero or less on initial load, the depleted state is recognized and acted upon promptly.
3.  Added minor robustness improvements, such as checking if DOM elements exist before manipulating them and attempting to find `.chat-messages-list` with a slight delay if not immediately present.

This ensures that you, when starting with no gasergy, see the correct 'Out of Gasergy' message and have the input disabled before you can interact with the chat.