### PR TITLE
Add login checks across course pages

### DIFF
--- a/advanced/01_html5_apis.php
+++ b/advanced/01_html5_apis.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/advanced/02_canvas_svg.php
+++ b/advanced/02_canvas_svg.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/advanced/03_web_components.php
+++ b/advanced/03_web_components.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/advanced/04_microdata.php
+++ b/advanced/04_microdata.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/advanced/05_performance_optimization.php
+++ b/advanced/05_performance_optimization.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/advanced/06_integration.php
+++ b/advanced/06_integration.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/ai_chat/index.php
+++ b/ai_chat/index.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/auth-system/login_check.php
+++ b/auth-system/login_check.php
@@ -1,0 +1,7 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /auth-system/frt_login.php');
+    exit;
+}
+?>

--- a/basics/01_introduction.php
+++ b/basics/01_introduction.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/basics/02_document_structure.php
+++ b/basics/02_document_structure.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/basics/03_text_elements.php
+++ b/basics/03_text_elements.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/basics/04_links.php
+++ b/basics/04_links.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/basics/05_images.php
+++ b/basics/05_images.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/basics/06_lists.php
+++ b/basics/06_lists.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/basics/07_tables.php
+++ b/basics/07_tables.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/basics/08_forms.php
+++ b/basics/08_forms.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/index.php
+++ b/index.php
@@ -4,19 +4,9 @@ ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 file_put_contents(__DIR__ . '/index_debug.log', date('c') . " index.php loaded\n", FILE_APPEND);
-?>
-<?php
-session_start();
-//file_put_contents(__DIR__ . '/debug.log', date('c') . " index.php loaded\n", FILE_APPEND);
 
-if (!isset($_SESSION['user_id'])) {
-    file_put_contents(__DIR__ . '/debug.log', date('c') . " No session detected\n", FILE_APPEND);
-    header('Location: auth-system/frt_login.php');
-    exit;
-}
-
-//file_put_contents(__DIR__ . '/debug.log', date('c') . " User session active: " . $_SESSION['user_id'] . "\n", FILE_APPEND);
-
+require_once __DIR__ . '/auth-system/login_check.php';
+require_once __DIR__ . '/auth-system/config/db.php';
 
 file_put_contents(__DIR__ . '/index_debug.log', "User ID: " . $_SESSION['user_id'] . "\n", FILE_APPEND);
 ?>
@@ -24,7 +14,6 @@ file_put_contents(__DIR__ . '/index_debug.log', "User ID: " . $_SESSION['user_id
 
 <?php
 if (isset($_SESSION['user_id'])) {
-    require_once __DIR__ . '/auth-system/config/db.php';
     $stmt = $pdo->prepare("SELECT gasergy_balance FROM users WHERE id = ?");
     $stmt->execute([$_SESSION['user_id']]);
     $balance = $stmt->fetchColumn();

--- a/intermediate/01_semantic_elements.php
+++ b/intermediate/01_semantic_elements.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/intermediate/02_metadata.php
+++ b/intermediate/02_metadata.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/intermediate/03_accessibility.php
+++ b/intermediate/03_accessibility.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/intermediate/04_character_entities.php
+++ b/intermediate/04_character_entities.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/intermediate/05_embedding_content.php
+++ b/intermediate/05_embedding_content.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/intermediate/06_advanced_forms.php
+++ b/intermediate/06_advanced_forms.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/../auth-system/login_check.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
## Summary
- add reusable `login_check.php`
- use login check in `index.php`
- enforce login on all lesson and AI chat pages

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_685254dac5d88321a9121996fd55c255