### PR TITLE
Add Stripe payment workflow for Gasergy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 debug.log
 register_error.log
 gasergy/decrease_debug.log
+
+/vendor/
+composer.lock
+# logs
+*.log

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "stripe/stripe-php": "^17.3"
+    }
+}

--- a/config/stripe.php
+++ b/config/stripe.php
@@ -1,0 +1,23 @@
+<?php
+// Load Stripe configuration from environment variables.
+// Replace placeholders with your actual keys in production or set environment variables.
+$stripeSecretKey = getenv('STRIPE_SECRET_KEY') ?: 'sk_test_placeholder';
+$stripePublishableKey = getenv('STRIPE_PUBLISHABLE_KEY') ?: 'pk_test_placeholder';
+$stripeWebhookSecret = getenv('STRIPE_WEBHOOK_SECRET') ?: 'whsec_placeholder';
+
+// Map Gasergy amounts to Stripe Price IDs.
+$gasergyPrices = [
+    // Starter – $2.50 for 500 Gasergy
+    500    => 'price_500g_placeholder',
+    // Professional – $10 for 2 500 Gasergy
+    2500   => 'price_2500g_placeholder',
+    // Business – $30 for 10 000 Gasergy
+    10000  => 'price_10000g_placeholder',
+    // Enterprise – $125 for 50 000 Gasergy
+    50000  => 'price_50000g_placeholder',
+];
+
+function priceForGasergy(int $amount): ?string {
+    global $gasergyPrices;
+    return $gasergyPrices[$amount] ?? null;
+}

--- a/gasergy/create_checkout_session.php
+++ b/gasergy/create_checkout_session.php
@@ -1,0 +1,38 @@
+<?php
+session_start();
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../auth-system/config/db.php';
+require_once __DIR__ . '/../config/stripe.php';
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(403);
+    exit('Unauthorized');
+}
+
+$amount = intval($_POST['amount'] ?? 0);
+$priceId = priceForGasergy($amount);
+if ($amount <= 0 || !$priceId) {
+    http_response_code(400);
+    exit('Invalid amount');
+}
+
+\Stripe\Stripe::setApiKey($stripeSecretKey);
+
+try {
+    $session = \Stripe\Checkout\Session::create([
+        'mode' => 'payment',
+        'line_items' => [[
+            'price' => $priceId,
+            'quantity' => 1,
+        ]],
+        'success_url' => '/gasergy/success.php?session_id={CHECKOUT_SESSION_ID}',
+        'cancel_url'  => '/gasergy/get.php',
+        'client_reference_id' => $_SESSION['user_id'],
+        'metadata' => ['amount' => $amount],
+    ]);
+    header('Location: ' . $session->url, true, 303);
+    exit;
+} catch (Exception $e) {
+    http_response_code(500);
+    echo 'Error creating checkout session';
+}

--- a/gasergy/get.php
+++ b/gasergy/get.php
@@ -21,42 +21,111 @@ if (!isset($_SESSION['user_id'])) {
       text-align: center;
       padding: 50px;
     }
-    .option {
-      display: inline-block;
-      padding: 20px;
-      margin: 20px;
+    .pricing-grid {
+      display: flex;
+      justify-content: center;
+      gap: 20px;
+      flex-wrap: wrap;
+    }
+    .plan {
       background: white;
       border: 2px solid #3498db;
       border-radius: 10px;
+      padding: 20px;
+      width: 200px;
+    }
+    .plan h2 {
+      margin-top: 0;
+    }
+    .plan .price {
+      font-size: 24px;
+      margin: 10px 0;
+    }
+    .plan .gasergy {
+      color: #555;
+      margin: 10px 0 20px;
+    }
+    .popular {
+      background: #3498db;
+      color: white;
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-size: 12px;
+    }
+    .option {
+      background: #3498db;
+      color: white;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 5px;
       cursor: pointer;
     }
     .option:hover {
-      background: #e0f3ff;
-    }
-    form {
-      display: inline;
+      background: #2879b8;
     }
   </style>
 </head>
 <body>
 
   <h1>Get Gasergy ⚡</h1>
-  <p>Select how much Gasergy you want to add to your account:</p>
+  <p>Select your plan:</p>
 
-  <form action="add.php" method="POST">
-    <input type="hidden" name="amount" value="10">
-    <button class="option">+10 Gasergy</button>
-  </form>
+  <div class="pricing-grid">
+    <div class="plan">
+      <h2>Starter</h2>
+      <p class="price">$2.50</p>
+      <p class="gasergy">500 Gasergy</p>
+      <form action="create_checkout_session.php" method="POST">
+        <input type="hidden" name="amount" value="500">
+        <button class="option">Buy</button>
+      </form>
+    </div>
 
-  <form action="add.php" method="POST">
-    <input type="hidden" name="amount" value="50">
-    <button class="option">+50 Gasergy</button>
-  </form>
+    <div class="plan">
+      <h2>Professional <span class="popular">Popular</span></h2>
+      <p class="price">$10</p>
+      <p class="gasergy">2 500 Gasergy</p>
+      <form action="create_checkout_session.php" method="POST">
+        <input type="hidden" name="amount" value="2500">
+        <button class="option">Buy</button>
+      </form>
+    </div>
 
-  <form action="add.php" method="POST">
-    <input type="hidden" name="amount" value="100">
-    <button class="option">+100 Gasergy</button>
-  </form>
+    <div class="plan">
+      <h2>Business</h2>
+      <p class="price">$30</p>
+      <p class="gasergy">10 000 Gasergy</p>
+      <form action="create_checkout_session.php" method="POST">
+        <input type="hidden" name="amount" value="10000">
+        <button class="option">Buy</button>
+      </form>
+    </div>
+  </div>
+
+  <p class="enterprise-note">Need &gt;10 000 Gasergy per month?
+    <a href="mailto:sales@example.com">Contact sales</a>
+    or <a href="#" id="show-enterprise">self-serve Enterprise</a>
+  </p>
+
+  <div id="enterprise" style="display:none; margin-top:20px;">
+    <div class="plan">
+      <h2>Enterprise</h2>
+      <p class="price">$125</p>
+      <p class="gasergy">50 000 Gasergy</p>
+      <form action="create_checkout_session.php" method="POST">
+        <input type="hidden" name="amount" value="50000">
+        <button class="option">Buy</button>
+      </form>
+    </div>
+  </div>
+
+  <script>
+  document.getElementById('show-enterprise').addEventListener('click', function(e) {
+    e.preventDefault();
+    document.getElementById('enterprise').style.display = 'block';
+    this.style.display = 'none';
+  });
+  </script>
 
 </body>
 </html>

--- a/gasergy/success.php
+++ b/gasergy/success.php
@@ -1,0 +1,35 @@
+<?php
+session_start();
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../config/stripe.php';
+
+\Stripe\Stripe::setApiKey($stripeSecretKey);
+$sessionId = $_GET['session_id'] ?? '';
+$amount = '';
+$amountFormatted = '';
+if ($sessionId) {
+    try {
+        $session = \Stripe\Checkout\Session::retrieve($sessionId);
+        $amount = $session->metadata->amount ?? '';
+        $amountFormatted = number_format((int)$amount);
+    } catch (Exception $e) {
+        // ignore errors, just show generic success
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Gasergy Purchase Success</title>
+</head>
+<body>
+  <h1>Payment Successful!</h1>
+<?php if ($amount) : ?>
+  <p>You purchased <?php echo htmlspecialchars($amountFormatted); ?> Gasergy.</p>
+<?php else : ?>
+  <p>Thank you for your purchase.</p>
+<?php endif; ?>
+  <p><a href="get.php">Back to Get Gasergy</a></p>
+</body>
+</html>

--- a/gasergy/webhook.php
+++ b/gasergy/webhook.php
@@ -1,0 +1,35 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../auth-system/config/db.php';
+require_once __DIR__ . '/../config/stripe.php';
+
+$payload = @file_get_contents('php://input');
+$sigHeader = $_SERVER['HTTP_STRIPE_SIGNATURE'] ?? '';
+
+try {
+    $event = \Stripe\Webhook::constructEvent(
+        $payload,
+        $sigHeader,
+        $stripeWebhookSecret
+    );
+} catch (Exception $e) {
+    http_response_code(400);
+    exit('Invalid signature');
+}
+
+if ($event->type === 'checkout.session.completed') {
+    $session = $event->data->object;
+    $userId = $session->client_reference_id;
+    $amount = intval($session->metadata->amount ?? 0);
+
+    if ($userId && $amount > 0) {
+        try {
+            $stmt = $pdo->prepare("UPDATE users SET gasergy_balance = gasergy_balance + ? WHERE id = ?");
+            $stmt->execute([$amount, $userId]);
+        } catch (Exception $e) {
+            // log error in real setup
+        }
+    }
+}
+
+http_response_code(200);


### PR DESCRIPTION
## Summary
- ignore Composer vendor and log files
- add Stripe library via Composer
- map Stripe config and prices in `config/stripe.php`
- create `create_checkout_session.php` for initiating Stripe Checkout
- wire purchase forms in `get.php` to use Stripe
- add success page and webhook handler for completed payments
- **revamp pricing tiers and UI** with Starter, Professional, Business, and hidden Enterprise

## Testing
- `php -l config/stripe.php`
- `php -l gasergy/get.php`
- `php -l gasergy/create_checkout_session.php`
- `php -l gasergy/webhook.php`
- `php -l gasergy/success.php`


------
https://chatgpt.com/codex/tasks/task_e_68525431fff883218d1ebdd85aa622ea