### PR TITLE
Integrate dotenv loader

### DIFF
--- a/auth-system/config/db.php
+++ b/auth-system/config/db.php
@@ -1,8 +1,10 @@
 <?php
-$host = 'localhost';
+require_once __DIR__ . '/../../config/env.php';
+
+$host = getenv('DB_HOST') ?: 'localhost';
 $db   = 'robot_network';
-$user = 'srn_user';
-$pass = 'J0j0j0j0!';
+$user = getenv('DB_USER') ?: 'srn_user';
+$pass = getenv('DB_PASS') ?: 'J0j0j0j0!';
 $charset = 'utf8mb4';
 
 $dsn = "mysql:host=$host;dbname=$db;charset=$charset";
@@ -17,3 +19,4 @@ try {
 } catch (\PDOException $e) {
      throw new \PDOException($e->getMessage(), (int)$e->getCode());
 }
+?>

--- a/config/env.php
+++ b/config/env.php
@@ -1,0 +1,26 @@
+<?php
+// Simple environment variable loader
+// Looks for a .env file in this directory or project root and sets variables
+
+$paths = [__DIR__ . '/.env', dirname(__DIR__) . '/.env'];
+foreach ($paths as $path) {
+    if (is_readable($path)) {
+        foreach (file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+            if (strpos(trim($line), '#') === 0) {
+                continue;
+            }
+            if (!strpos($line, '=')) {
+                continue;
+            }
+            list($name, $value) = array_map('trim', explode('=', $line, 2));
+            if ($name !== '' && getenv($name) === false) {
+                putenv("{$name}={$value}");
+                $_ENV[$name] = $value;
+                $_SERVER[$name] = $value;
+            }
+        }
+        break;
+    }
+}
+
+?>

--- a/config/stripe.php
+++ b/config/stripe.php
@@ -1,4 +1,8 @@
 <?php
+$envPath = __DIR__ . '/env.php';
+if (file_exists($envPath)) {
+    require_once $envPath;
+}
 // Load Stripe configuration from environment variables.
 // Replace placeholders with your actual keys in production or set environment variables.
 $stripeSecretKey = getenv('STRIPE_SECRET_KEY') ?: 'sk_test_placeholder';


### PR DESCRIPTION
## Summary
- create `config/env.php` to parse `.env` files
- load env variables before configuring Stripe
- use env variables for DB credentials

## Testing
- `php -v` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a20d1c6048321913683b9351b3264