### PR TITLE
Improve subscription logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,15 @@ Users can purchase subscription plans via Stripe and manage their plan from the
 ## New subscription management
 
 * `gasergy/manage_subscription.php` shows the current plan, allows upgrading or
-  downgrading, and provides a cancel button.
-* `gasergy/update_subscription.php` updates the Stripe subscription.
+  downgrading, and provides a cancel button. Upgrade messages display based on
+  the result of the last change.
+* `gasergy/confirm_upgrade.php` warns users of the prorated charge before the
+  subscription is updated and logs any Stripe errors.
+* `gasergy/update_subscription.php` updates the Stripe subscription and
+  redirects back with a success or pending status depending on whether the
+  invoice was paid.
+* `gasergy/update_payment.php` opens the Stripe billing portal so a user can
+  update their payment method if a charge fails and logs failures.
 * `gasergy/cancel_subscription.php` sets the subscription to cancel at the end
   of the billing period.
 * Monthly renewals are processed in `gasergy/webhook.php` when Stripe sends an

--- a/gasergy/manage_subscription.php
+++ b/gasergy/manage_subscription.php
@@ -72,6 +72,15 @@ if ($userSub) {
     <title>Manage Subscription</title>
 </head>
 <body>
+<?php if (isset($_GET['update'])): ?>
+    <?php if ($_GET['update'] === 'success'): ?>
+        <p style="color:green;">Upgrade successful and invoice paid.</p>
+    <?php elseif ($_GET['update'] === 'pending'): ?>
+        <p style="color:orange;">Subscription updated but payment is pending.</p>
+    <?php else: ?>
+        <p style="color:red;">Upgrade failed. <a href="update_payment.php">Update your payment information</a> and try again.</p>
+    <?php endif; ?>
+<?php endif; ?>
 <h1>Your Gasergy Subscription</h1>
 <?php if ($subscription): ?>
     <?php
@@ -85,7 +94,7 @@ if ($userSub) {
     <p>Status: <?php echo $status; ?></p>
     <p>Next billing date: <?php echo $nextBilling; ?></p>
     <h2>Change Plan</h2>
-    <form action="update_subscription.php" method="POST">
+    <form action="confirm_upgrade.php" method="POST">
         <select name="amount">
             <option value="500">Starter - 500 Gasergy/month</option>
             <option value="2500">Professional - 2 500 Gasergy/month</option>


### PR DESCRIPTION
## Summary
- log errors in `confirm_upgrade.php` and `update_payment.php`
- log unexpected failures in `update_subscription.php`
- document logging behavior in README

## Testing
- `composer install`
- `php -l gasergy/confirm_upgrade.php`
- `php -l gasergy/update_payment.php`
- `php -l gasergy/update_subscription.php`
- `php -l gasergy/manage_subscription.php`


------
https://chatgpt.com/codex/tasks/task_e_6876db4981d88321aae9e5d34a6c00c9