### PR TITLE
Fix(stripe): Replace deprecated upcoming method with createPreview

### DIFF
--- a/auth-system/login_check.php
+++ b/auth-system/login_check.php
@@ -1,5 +1,7 @@
 <?php
-session_start();
+if (session_status() == PHP_SESSION_NONE) {
+    session_start();
+}
 
 // Determine the root directory of the application (one level above this file)
 $appRoot = dirname(__DIR__);

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,9 @@
 {
     "require": {
         "stripe/stripe-php": "^17.3"
+    },
+    "require-dev": {
+        "php-mock/php-mock": "^2.6",
+        "phpunit/phpunit": "^12.2"
     }
 }

--- a/gasergy/ConfirmUpgradeTest.php
+++ b/gasergy/ConfirmUpgradeTest.php
@@ -1,0 +1,59 @@
+<?php
+// Test for confirm_upgrade.php
+
+// Set up test environment
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../config/stripe.php';
+
+class ConfirmUpgradeTest extends \PHPUnit\Framework\TestCase
+{
+    protected $pdo;
+
+    protected function setUp(): void
+    {
+        require __DIR__ . '/../auth-system/config/db.php';
+        $this->pdo = $pdo;
+        // Create a test user
+        $email = 'testuser@example.com';
+        $password = 'password';
+        $hashed_password = password_hash($password, PASSWORD_DEFAULT);
+        $stripe_customer_id = 'cus_test123';
+        $stripe_subscription_id = 'sub_test123';
+
+        $stmt = $this->pdo->prepare("INSERT INTO users (email, password, stripe_customer_id, stripe_subscription_id) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE password = ?, stripe_customer_id = ?, stripe_subscription_id = ?");
+        $stmt->execute([$email, $hashed_password, $stripe_customer_id, $stripe_subscription_id, $hashed_password, $stripe_customer_id, $stripe_subscription_id]);
+
+        $stmt = $this->pdo->prepare("SELECT id FROM users WHERE email = ?");
+        $stmt->execute([$email]);
+        $userId = $stmt->fetchColumn();
+        $_SESSION['user_id'] = $userId;
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up the test user
+        $stmt = $this->pdo->prepare("DELETE FROM users WHERE email = ?");
+        $stmt->execute(['testuser@example.com']);
+    }
+
+    public function testConfirmUpgrade()
+    {
+        // Simulate a POST request
+        $_POST['amount'] = 500;
+
+        // Capture the output of the script
+        ob_start();
+        include __DIR__ . '/confirm_upgrade.php';
+        $output = ob_get_clean();
+
+        // Debugging
+        echo $output;
+
+        // Assertions
+        $this->assertStringContainsString('<h1>Confirm Plan Change</h1>', $output);
+        $this->assertStringContainsString('$10.00', $output);
+    }
+}

--- a/gasergy/confirm_upgrade.php
+++ b/gasergy/confirm_upgrade.php
@@ -40,15 +40,13 @@ try {
 
     $itemId = $subscription->items->data[0]->id;
     // Estimate proration cost using upcoming invoice
-    $invoice = \Stripe\Invoice::upcoming([
+    $invoice = \Stripe\Invoice::createPreview([
         'customer' => $subscription->customer,
-        'subscription_details' => [
-            'subscription' => $subscriptionId,
-            'items' => [
-                ['id' => $itemId, 'price' => $priceId]
-            ],
-            'proration_behavior' => 'create_prorations'
-        ]
+        'subscription' => $subscriptionId,
+        'subscription_items' => [
+            ['id' => $itemId, 'price' => $priceId]
+        ],
+        'subscription_proration_behavior' => 'create_prorations'
     ]);
     $amountDue = $invoice->amount_due / 100; // convert from cents
 

--- a/gasergy/simple_test.php
+++ b/gasergy/simple_test.php
@@ -1,0 +1,36 @@
+<?php
+// Simple test for confirm_upgrade.php
+
+// Set up test environment
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../config/stripe.php';
+require_once __DIR__ . '/../auth-system/config/db.php';
+
+// Create a test user
+$email = 'testuser@example.com';
+$password = 'password';
+$hashed_password = password_hash($password, PASSWORD_DEFAULT);
+$stripe_customer_id = 'cus_test123';
+$stripe_subscription_id = 'sub_test123';
+
+$stmt = $pdo->prepare("INSERT INTO users (email, password, stripe_customer_id, stripe_subscription_id) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE password = ?, stripe_customer_id = ?, stripe_subscription_id = ?");
+$stmt->execute([$email, $hashed_password, $stripe_customer_id, $stripe_subscription_id, $hashed_password, $stripe_customer_id, $stripe_subscription_id]);
+
+$stmt = $pdo->prepare("SELECT id FROM users WHERE email = ?");
+$stmt->execute([$email]);
+$userId = $stmt->fetchColumn();
+$_SESSION['user_id'] = $userId;
+
+// Simulate a POST request
+$_POST['amount'] = 500;
+
+// Include the script
+include __DIR__ . '/confirm_upgrade.php';
+
+// Clean up the test user
+$stmt = $pdo->prepare("DELETE FROM users WHERE email = ?");
+$stmt->execute(['testuser@example.com']);
+?>


### PR DESCRIPTION
The upcoming method on the Stripe Invoice object has been deprecated. This commit replaces it with the createPreview method to ensure compatibility with the latest Stripe API.