### PR TITLE
Fix missing log_checkout function

### DIFF
--- a/gasergy/create_checkout_session.php
+++ b/gasergy/create_checkout_session.php
@@ -9,6 +9,10 @@ session_start();
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../config/stripe.php';
 
+function log_checkout($msg) {
+    error_log($msg);
+}
+
 $baseUrl = rtrim(getenv('BASE_URL') ?: '', '/');
 
 log_checkout('start user=' . ($_SESSION['user_id'] ?? 'none') . ' amount=' . ($_POST['amount'] ?? ''));


### PR DESCRIPTION
## Summary
- define `log_checkout()` in `gasergy/create_checkout_session.php`

## Testing
- `php -l gasergy/create_checkout_session.php`

------
https://chatgpt.com/codex/tasks/task_e_68819e9e45788321b4040fe01248f0a9