### PR TITLE
Fix gasergy balance when upgrading subscription

### DIFF
--- a/gasergy/update_subscription.php
+++ b/gasergy/update_subscription.php
@@ -55,8 +55,7 @@ try {
         ],
         'proration_behavior' => 'create_prorations'
     ]);
-    $stmt = $pdo->prepare("UPDATE users SET subscription_gasergy = ? WHERE id = ?");
-    $stmt->execute([$amount, $userId]);
+    // The user's plan will be updated in webhook.php after the invoice is paid
 
     // check invoice status
     $invoiceId = $updated->latest_invoice;


### PR DESCRIPTION
## Summary
- stop updating `subscription_gasergy` directly during subscription updates
- let `webhook.php` adjust the plan once the invoice is paid

## Testing
- `composer install`
- `./vendor/bin/phpunit gasergy/ConfirmUpgradeTest.php` *(fails: `PDOException: SQLSTATE[HY000] [2002] No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6885cf98aa988321b38faaa2a98b06de