### PR TITLE
Fix: Separate subscription update into two API calls

### DIFF
--- a/gasergy/update_subscription.php
+++ b/gasergy/update_subscription.php
@@ -48,8 +48,14 @@ try {
     log_subscription('Stripe retrieved subscription id=' . $subscriptionId);
 
     $itemId = $subscription->items->data[0]->id;
+
+    // First, ensure the subscription is not set to be cancelled
     \Stripe\Subscription::update($subscriptionId, [
         'cancel_at_period_end' => false,
+    ]);
+
+    // Then, update the price and charge immediately
+    \Stripe\Subscription::update($subscriptionId, [
         'items' => [
             ['id' => $itemId, 'price' => $priceId]
         ],


### PR DESCRIPTION
This commit fixes a Stripe API error that occurred during subscription upgrades. The error `When payment_behavior is set to pending_if_incomplete, you can only pass supported params. cancel_at_period_end is not supported` was triggered because the code was attempting to update both the subscription's price and its `cancel_at_period_end` status in a single API call.

The fix refactors the update logic in `gasergy/update_subscription.php` to use two separate `\Stripe\Subscription::update` calls. The first call ensures that `cancel_at_period_end` is set to `false`, and the second call updates the subscription's items, `proration_behavior`, and `payment_behavior`. This approach aligns with Stripe's recommended best practices and resolves the API error.