### PR TITLE
Fix: Retrieve full Invoice object in webhook handler

### DIFF
--- a/gasergy/webhook.php
+++ b/gasergy/webhook.php
@@ -55,7 +55,8 @@ switch ($event->type) {
         break;
     case 'invoice.paid':
         // handle subscription invoices
-        $invoice = $event->data->object;
+        $invoice_id = $event->data->object->id;
+        $invoice = \Stripe\Invoice::retrieve($invoice_id);
         $subscriptionId = $invoice->subscription;
         $billingReason = $invoice->billing_reason ?? '';
 


### PR DESCRIPTION
This commit fixes a critical bug where you were not receiving your purchased "gasergy" after a subscription upgrade.

The root cause was that the `invoice.paid` webhook handler was relying on the `Invoice` object provided in the webhook payload. This payload did not contain all the necessary properties (like `subscription` and `lines.data.type`), leading to "Undefined property" errors and a failure to calculate the gasergy amount.

The fix modifies the `gasergy/webhook.php` script to, upon receiving an `invoice.paid` event, use the invoice ID from the event to retrieve the full, complete `Invoice` object directly from the Stripe API. This ensures that all required properties are present and that the gasergy calculation and database update can proceed as expected.