### PR TITLE
Fix: Add missing Stripe API key to webhook handler

### DIFF
--- a/gasergy/webhook.php
+++ b/gasergy/webhook.php
@@ -9,6 +9,8 @@ require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../auth-system/config/db.php';
 require_once __DIR__ . '/../config/stripe.php';
 
+\Stripe\Stripe::setApiKey($stripeSecretKey);
+
 $payload = @file_get_contents('php://input');
 $sigHeader = $_SERVER['HTTP_STRIPE_SIGNATURE'] ?? '';
 


### PR DESCRIPTION
This commit fixes a fatal error in the `gasergy/webhook.php` script that was causing a "No API key provided" exception. This error prevented the webhook handler from retrieving the full `Invoice` object from Stripe, which in turn caused your "gasergy" balance to not be updated after a subscription upgrade.

The fix adds the `\Stripe\Stripe::setApiKey($stripeSecretKey);` line to the beginning of the script, ensuring that all subsequent API calls are properly authenticated. This resolves the fatal error and allows the webhook handler to function as intended.