### PR TITLE
Refactor: Move gasergy update to synchronous process

### DIFF
--- a/gasergy/update_subscription.php
+++ b/gasergy/update_subscription.php
@@ -67,6 +67,20 @@ try {
     // changes. This ensures that gasergy is added only after a successful
     // payment.
 
+    // Manually update gasergy balance
+    $stmt = $pdo->prepare("SELECT subscription_gasergy FROM users WHERE id = ?");
+    $stmt->execute([$userId]);
+    $oldGasergy = (int)($stmt->fetchColumn() ?: 0);
+    $diff = $amount - $oldGasergy;
+    if ($diff > 0) {
+        $stmt = $pdo->prepare(
+            "UPDATE users SET subscription_gasergy = ?, gasergy_balance = gasergy_balance + ? WHERE id = ?"
+        );
+        $stmt->execute([$amount, $diff, $userId]);
+    } else {
+        $stmt = $pdo->prepare("UPDATE users SET subscription_gasergy = ? WHERE id = ?");
+        $stmt->execute([$amount, $userId]);
+    }
 } catch (Exception $e) {
 
     log_subscription('Stripe error updating ' . $subscriptionId . ': ' . $e->getMessage());

--- a/gasergy/webhook.php
+++ b/gasergy/webhook.php
@@ -87,25 +87,6 @@ switch ($event->type) {
                     "UPDATE users SET gasergy_balance = gasergy_balance + ?, subscription_gasergy = ? WHERE id = ?"
                 );
                 $stmt->execute([$gasergyAmount, $gasergyAmount, $userId]);
-            } elseif ($billingReason === 'subscription_update') {
-                // Prorated upgrade, grant gasergy for the partial month
-                $stmt = $pdo->prepare("SELECT subscription_gasergy FROM users WHERE id = ?");
-                $stmt->execute([$userId]);
-                $oldGasergy = $stmt->fetchColumn();
-
-                if ($gasergyAmount > $oldGasergy) {
-                    $gasergyDifference = $gasergyAmount - $oldGasergy;
-                    $updateStmt = $pdo->prepare(
-                        "UPDATE users SET gasergy_balance = gasergy_balance + ?, subscription_gasergy = ? WHERE id = ?"
-                    );
-                    $updateStmt->execute([$gasergyDifference, $gasergyAmount, $userId]);
-                } else {
-                    // downgrade or same plan, just update the plan size
-                    $updateStmt = $pdo->prepare(
-                        "UPDATE users SET subscription_gasergy = ? WHERE id = ?"
-                    );
-                    $updateStmt->execute([$gasergyAmount, $userId]);
-                }
             }
         }
 


### PR DESCRIPTION
This commit refactors the "gasergy" update logic to be a synchronous process within the `update_subscription.php` script. This change addresses a persistent issue where your gasergy balances were not being updated correctly after a subscription upgrade due to unreliable data in the webhook payloads.

The new implementation calculates the gasergy difference and updates your balance in the database immediately after the Stripe subscription is successfully upgraded. This provides a more robust and instantaneous update for you.

The `invoice.paid` handler in `gasergy/webhook.php` has been simplified to remove the now-redundant logic for handling subscription upgrades, preventing any potential conflicts.