### PR TITLE
Use Stripe invoice preview API in manage_subscription

### DIFF
--- a/gasergy/manage_subscription.php
+++ b/gasergy/manage_subscription.php
@@ -37,13 +37,13 @@ if ($userSub) {
         log_subscription('Stripe subscription retrieved id=' . $userSub);
 
         try {
-            $upcomingInvoice = \Stripe\Invoice::upcoming([
-                'customer' => $subscription->customer,
-                'subscription' => $subscription->id
+            $upcomingInvoice = \Stripe\Invoice::createPreview([
+                'customer'     => $subscription->customer,
+                'subscription' => $subscription->id,
             ]);
-            log_subscription('Upcoming invoice retrieved for subscription=' . $subscription->id);
+            log_subscription('Upcoming invoice preview retrieved for subscription=' . $subscription->id);
         } catch (Exception $e) {
-            log_subscription('Stripe error retrieving upcoming invoice for ' . $userSub . ': ' . $e->getMessage());
+            log_subscription('Stripe error retrieving upcoming invoice preview for ' . $userSub . ': ' . $e->getMessage());
             $upcomingInvoice = null;
         }
     } catch (Exception $e) {


### PR DESCRIPTION
## Summary
- replace deprecated `Stripe\Invoice::upcoming()` with `Stripe\Invoice::createPreview()`
- adjust logging to reflect invoice preview

## Testing
- `php -l gasergy/manage_subscription.php`


------
https://chatgpt.com/codex/tasks/task_e_68a13c4275f483219754efff027074bf