### PR TITLE
Remove manual gasergy crediting during subscription update

### DIFF
--- a/gasergy/update_subscription.php
+++ b/gasergy/update_subscription.php
@@ -67,20 +67,6 @@ try {
     // changes. This ensures that gasergy is added only after a successful
     // payment.
 
-    // Manually update gasergy balance
-    $stmt = $pdo->prepare("SELECT subscription_gasergy FROM users WHERE id = ?");
-    $stmt->execute([$userId]);
-    $oldGasergy = (int)($stmt->fetchColumn() ?: 0);
-    $diff = $amount - $oldGasergy;
-    if ($diff > 0) {
-        $stmt = $pdo->prepare(
-            "UPDATE users SET subscription_gasergy = ?, gasergy_balance = gasergy_balance + ? WHERE id = ?"
-        );
-        $stmt->execute([$amount, $diff, $userId]);
-    } else {
-        $stmt = $pdo->prepare("UPDATE users SET subscription_gasergy = ? WHERE id = ?");
-        $stmt->execute([$amount, $userId]);
-    }
 } catch (Exception $e) {
 
     log_subscription('Stripe error updating ' . $subscriptionId . ': ' . $e->getMessage());


### PR DESCRIPTION
## Summary
- rely on the Stripe webhook to update plan credits
- remove manual updates to subscription_gasergy and gasergy_balance in `update_subscription.php`

## Testing
- `./vendor/bin/phpunit gasergy/ConfirmUpgradeTest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68adfbc770c0832187d7796e6e1168d2