### PR TITLE
Fallback gasergy amount from subscription in webhook

### DIFF
--- a/gasergy/webhook.php
+++ b/gasergy/webhook.php
@@ -71,6 +71,12 @@ switch ($event->type) {
             }
         }
 
+        if ($gasergyAmount === 0 && $subscriptionId) {
+            $subscription = \Stripe\Subscription::retrieve($subscriptionId);
+            $priceId = $subscription->items->data[0]->price->id ?? null;
+            $gasergyAmount = $priceId ? gasergyForPrice($priceId) : 0;
+        }
+
         $userId = null;
         if ($subscriptionId) {
             $stmt = $pdo->prepare(


### PR DESCRIPTION
## Summary
- ensure invoice webhook determines gasergy from subscription when invoice lines lack amount

## Testing
- `php -l gasergy/webhook.php`
- `./vendor/bin/phpunit gasergy/ConfirmUpgradeTest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae15e7ba44832195f23e893b29890e