### PR TITLE
Fix(gasergy): Correctly handle subscription upgrades in webhook

### DIFF
--- a/gasergy/webhook.php
+++ b/gasergy/webhook.php
@@ -63,6 +63,14 @@ switch ($event->type) {
 
         // Determine the plan from the invoice lines
         $gasergyAmount = 0;
+        if (!$subscriptionId) {
+            foreach ($invoice->lines->data as $line) {
+                if (($line->type ?? '') === 'subscription' && !empty($line->subscription)) {
+                    $subscriptionId = $line->subscription;
+                    break;
+                }
+            }
+        }
         foreach ($invoice->lines->data as $line) {
             if (($line->type ?? '') === 'subscription' && isset($line->price->id)) {
                 $gasergyAmount = gasergyForPrice($line->price->id) ?? 0;
@@ -123,9 +131,10 @@ switch ($event->type) {
     case 'invoice.created':
         // just log for now
         $invoice = $event->data->object;
+        $subscriptionId = $invoice->subscription ?? 'n/a';
         file_put_contents(
             $logFile,
-            "invoice.created: subscription={$invoice->subscription} " .
+            "invoice.created: subscription={$subscriptionId} " .
             "customer={$invoice->customer} reason={$invoice->billing_reason}\n",
             FILE_APPEND
         );


### PR DESCRIPTION
This commit fixes a bug where users would not receive gasergy after upgrading their subscription. The issue was caused by the `invoice.payment_succeeded` webhook handler failing to retrieve the subscription ID from the invoice object, as it is not always present at the top level for subscription update invoices.

The fix involves adding a fallback mechanism to iterate through the invoice lines and extract the subscription ID from there. This ensures that the user can be correctly identified and their gasergy balance updated.

Additionally, this commit fixes a PHP notice (`Undefined property: Stripe\Invoice::$subscription`) in the `invoice.created` event handler by adding a null coalescing operator to safely access the subscription property.