### PR TITLE
Fix(gasergy): Prevent double crediting on new subscriptions

### DIFF
--- a/gasergy/webhook.php
+++ b/gasergy/webhook.php
@@ -92,7 +92,7 @@ switch ($event->type) {
         }
 
         if ($userId && $gasergyAmount > 0) {
-            if (in_array($billingReason, ['subscription_cycle', 'subscription_create', 'subscription_update'], true)) {
+            if (in_array($billingReason, ['subscription_cycle', 'subscription_update'], true)) {
                 // Add credits and record plan size for new subscription, renewal, or upgrade
                 $stmt = $pdo->prepare(
                     "UPDATE users SET gasergy_balance = gasergy_balance + ?, subscription_gasergy = ? WHERE id = ?"


### PR DESCRIPTION
This commit resolves an issue where users received double the amount of gasergy upon initial subscription. The bug was introduced in a previous fix and was caused by both the `checkout.session.completed` and `invoice.payment_succeeded` webhook handlers crediting gasergy for the same purchase.

The fix ensures a clear separation of concerns:
- The `checkout.session.completed` handler is now solely responsible for crediting gasergy for the initial subscription purchase.
- The `invoice.payment_succeeded` handler has been modified to ignore invoices with the billing reason `subscription_create`. It will now only handle events for subscription renewals (`subscription_cycle`) and upgrades (`subscription_update`).

This change prevents the double-crediting issue while ensuring that renewals and upgrades continue to work correctly.