### PR TITLE
Ensure Gasergy balance updates in real time

### DIFF
--- a/ai_chat/index.php
+++ b/ai_chat/index.php
@@ -725,7 +725,7 @@ if (isset($_SESSION['user_id'])) {
           hideToggle: true,     // Hide toggle
           gasergy: {
             fetchPath: '../gasergy/decrease_gasergy.php', // Path for ai_chat/index.php
-            // No balanceDisplaySelector for ai_chat as it's fullscreen and doesn't show balance.
+            balanceDisplaySelector: '#gasergy-balance-display', // Update balance in real time
             refillPath: '../gasergy/get.php',
             balancePath: '../gasergy/get_balance.php'
           }

--- a/gasergy/decrease_gasergy.php
+++ b/gasergy/decrease_gasergy.php
@@ -4,6 +4,7 @@ ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 ini_set('log_errors', 1);
 ini_set('error_log', __DIR__ . '/decrease_gasergy.log');
+$logFile = __DIR__ . '/decrease_gasergy.log';
 
 session_start();
 


### PR DESCRIPTION
## Summary
- Display the user's Gasergy balance in AI chat without a page refresh
- Fix logging variable in Gasergy deduction endpoint to return clean JSON

## Testing
- `php -l ai_chat/index.php`
- `php -l gasergy/decrease_gasergy.php`


------
https://chatgpt.com/codex/tasks/task_e_68b536b890e48321a9314d1e505a8194